### PR TITLE
Add new site to Courses and Guides Sites

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,7 @@ List links and description
 | [Guru99](https://www.guru99.com/ethical-hacking-tutorials.html/) | Website with guides and a Free Ethical Hacking Course |
 | [PortSwigger Labs](https://portswigger.net/web-security) | Free learning resources focused on web and API security only | 
 | [DarkRelay Security Labs](https://darkrelay.com/training) | Free & paid cybersecurity trainings with certifications | 
+| [LabEx](https://labex.io/skilltrees/cybersecurity)  | Free & paid cybersecurity hands-on labs  | 
 
 ### <a name="os"></a>OS - Operation Systens 
 | Link | Description | 


### PR DESCRIPTION
Add LabEx to Courses and Guides Sites.

I work at LabEx, a unique learning platform that has delivered thousands of hands-on labs over the past 7 years. Our Cybersecurity Skill Tree currently offers 34 foundational skills and 80 hands-on labs, making it perfect for beginners to learn cybersecurity step by step. 

This repo is a great resource. Please let me know if any changes are needed.