### PR TITLE
Add OopsSec Store to CTF and Training section

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,7 @@ List links and description
 | [Trailofbits Github](https://trailofbits.github.io/ctf/) | CTF Field Guide |
 | [Shellter](https://shellterlabs.com) | Social Network focused on information security |
 | [CyberPython](https://pythoncyber.go.ro) | Practical cyber security challenges with own research |
+| [OSS – OopsSec Store](https://github.com/kOaDT/oss-oopssec-store) | Self-hosted CTF platform with intentionally vulnerable e-commerce application. Quick setup with `npx create-oss-store`. |
 
 ### <a name="hackactivism"></a>Non-legal Cyber activism
 | Link | Description | 


### PR DESCRIPTION
This PR adds OopsSec Store to the CTF, Training L3g@l and G@mes section.

I am the owner and maintainer of this project. I believe it can be a valuable resource for the cybersecurity community and would like to share it with others who might find it useful for security training, CTF practice, and web application security education.

The project is a self-hosted Capture The Flag platform featuring an intentionally vulnerable e-commerce application built with Next.js and React. It includes OWASP Top 10 vulnerabilities, API security flaws, and modern frontend attack vectors. The application can be quickly set up using `npx create-oss-store` and provides a production-like application environment with REST APIs for realistic security testing scenarios.

Repository: https://github.com/kOaDT/oss-oopssec-store