### PR TITLE
Add AzureFox to Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,6 +171,7 @@ List links and description
 | [zeek2es](https://github.com/corelight/zeek2es)       | Converts Zeek logs to Elastic/OpenSearch.                              |
 | [subdomainradar](https://subdomainradar.io)           | All-in-one recon platform: 50+ data sources for subdomain discovery, port & vulnerability scans, screenshots, and API access |
 | [leakradar](https://leakradar.io)                     | Instant search across 2 B+ plain-text info-stealer credentials; email, domain, metadata queries, monitoring & API |
+| [AzureFox](https://github.com/TacoRocket/AzureFox)    | Azure attack-path and privilege-chaining CLI for surfacing high-impact paths, usable pivots, and trust boundaries to break. |
 
 
 ### <a name="books"></a>Books


### PR DESCRIPTION
This PR adds AzureFox to the Tools section.

AzureFox is an open-source Azure attack-path and privilege-chaining CLI focused on surfacing high-impact paths, usable pivots, and trust boundaries from Azure control-plane visibility.

Thanks for maintaining the list.
