### PR TITLE
Add defend.network to Informatives and blogs

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ List links and description
 | [Advisory Week](https://advisoryweek.com/) | Security Advisories published by major vendors this week |
 | [InfoStealers by Hudson Rock](https://www.infostealers.com/) | The all-around Infostealer malware hub with recent news and publications |
 | [SecOps Bit By Bit: Roadmap for First-Time CTOs and Startup Founders](https://leanpub.com/secops-bit-by-bit) | This book is a compilation of best practices for evaluating weak spots in a product and company, and fostering a robust security culture |
+| [defend.network](https://defend.network) | Free, no-login cyber threat intelligence: daily threat briefings and weekly vulnerability reports, with every CVE cross-checked against NVD and the CISA KEV catalog |
 
 ### <a name="training"></a>CTF, Training L3g@l and G@mes
 | Link | Description | 


### PR DESCRIPTION
Adds [defend.network](https://defend.network) to the **Informatives and blogs** section.

defend.network is a free, no-login cyber threat intelligence site publishing daily threat briefings and weekly vulnerability reports, with every CVE cross-checked against NVD and the CISA KEV catalog. Content is structured by threat type, industry, and severity, with remediation guidance. An RSS feed is available at https://defend.network/feed.xml.

Thanks for maintaining this list!