### PR TITLE
Add IPASIS to Tools section

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,6 +152,7 @@ List links and description
 | [Ghidra](https://ghidra-sre.org/)                     | NSA reverse engineering tool.                                          |
 | [ghidraMCP](https://github.com/LaurieWired/GhidraMCP) | Autonomous reverse engineering with Ghidra using Model Context Protocol.|
 | [Hudson Rock](https://www.hudsonrock.com/threat-intelligence-cybercrime-tools) | Infostealer malware exposure checker.                        |
+| [IPASIS](https://ipasis.com)                          | Real-time bot detection and fraud prevention API with IP reputation, proxy/VPN detection, and email validation. |
 | [Metasploit Framework](https://www.metasploit.com/)   | Pentesting framework used by Kali Linux.                               |
 | [Netcat](http://netcat.sourceforge.net/)              | Networking utility for TCP/IP protocol.                                |
 | [NMap](https://nmap.org/)                             | Network discovery and security auditing tool.                          |


### PR DESCRIPTION
Adds [IPASIS](https://ipasis.com) to the Tools section — a real-time bot detection and fraud prevention API.

It combines IP reputation scoring, VPN/proxy/Tor detection, and email validation in a single REST endpoint with sub-20ms response times. Free tier includes 100 requests/day.

Placed alphabetically between Hudson Rock and Metasploit Framework.